### PR TITLE
Added a few examples to cover some information that wasn't previously covered in the docs

### DIFF
--- a/website/docs/marketplace/examples/example-app-branding.md
+++ b/website/docs/marketplace/examples/example-app-branding.md
@@ -23,3 +23,28 @@ The default color will be whatever the creator has set to be their "primary" col
 - @secondary
 - @default
 - @text
+
+You can also use the code `@contrast` to designate a contrast with a different color. Example:
+
+```json
+{
+  ...
+  "props": [
+    {
+      "name": "backgroundColor",
+      "displayName": "Background Color",
+      "type": "color",
+      "default": "@primary"
+    },
+    {
+      "name": "textColor",
+      "displayName": "Text Color",
+      "type": "color",
+      "default": "@contrast:backgroundColor"
+    }
+  ]
+}
+```
+
+In this case, `textColor` will, by default, be the best contrast with `backgroundColor`. This means
+that if the background color is light, the text color will be dark, and vice versa.

--- a/website/docs/marketplace/examples/example-editor-prop.md
+++ b/website/docs/marketplace/examples/example-editor-prop.md
@@ -1,0 +1,27 @@
+---
+id: example-editor-prop
+title: Conditionally Render Based on Context
+---
+
+Sometimes when you add your component to the editor, the library doesn't display anything unless
+you're looking at it in preview. In these cases, it is still important to render *something* in
+the editor. Every component is passed an `editor` prop, a flag that returns true when the component
+is rendered in the editor. You can use this prop to conditionally render something:
+
+```javascript
+export default class AdaloComponent extends Component {
+  render() {
+    const { editor } = this.props
+    if(editor) {
+      return <Text>I'm being rendered inside editor!</Text>
+    }
+    else {
+      return <RealComponent/>
+    }
+  }
+}
+```
+
+In this example, if the component is being rendered inside the editor, the text will render instead
+of `RealComponent`. Make sure whatever is being rendered is representative of what will be rendered
+in the user's actual app.

--- a/website/docs/marketplace/examples/example-editor-prop.md
+++ b/website/docs/marketplace/examples/example-editor-prop.md
@@ -8,7 +8,7 @@ you're looking at it in preview. In these cases, it is still important to render
 the editor. Every component is passed an `editor` prop, a flag that returns true when the component
 is rendered in the editor. You can use this prop to conditionally render something:
 
-```javascript
+```jsx
 export default class AdaloComponent extends Component {
   render() {
     const { editor } = this.props

--- a/website/docs/marketplace/examples/example-force-rerender.md
+++ b/website/docs/marketplace/examples/example-force-rerender.md
@@ -1,0 +1,29 @@
+---
+id: example-force-rerender
+title: Force Component to Re-Render
+---
+
+Sometimes, some parts of a component will not re-render in the editor, even if you change a value. 
+In order to force a re-render, you can add a `key` prop to the component like so:
+
+```javascript
+export default class AdaloComponent extends Component {
+  render() {
+    const { iconSize, iconColor } = this.props
+    return (
+      <Icon
+        key={`playButton.${iconSize}`}
+        color={iconColor}
+        size={iconSize}
+      />
+    )
+  }
+}
+```
+
+In this example, the problem was that `Icon` would not re-render in the editor when I changed its size.
+To fix this issue, I added a prop to `Icon` called `key`. Its value is a string that changes value whenever
+`iconSize` changes value. It is also a unique string, meaning that if I have multiple icons they each need to
+have their own key value. 
+
+With this key prop, `Icon` will automatically re-render every time the icon size prop changes.

--- a/website/docs/marketplace/examples/example-force-rerender.md
+++ b/website/docs/marketplace/examples/example-force-rerender.md
@@ -6,7 +6,7 @@ title: Force Component to Re-Render
 Sometimes, some parts of a component will not re-render in the editor, even if you change a value. 
 In order to force a re-render, you can add a `key` prop to the component like so:
 
-```javascript
+```jsx
 export default class AdaloComponent extends Component {
   render() {
     const { iconSize, iconColor } = this.props
@@ -21,9 +21,9 @@ export default class AdaloComponent extends Component {
 }
 ```
 
-In this example, the problem was that `Icon` would not re-render in the editor when I changed its size.
-To fix this issue, I added a prop to `Icon` called `key`. Its value is a string that changes value whenever
-`iconSize` changes value. It is also a unique string, meaning that if I have multiple icons they each need to
+In this example, the problem was that `Icon` would not re-render in the editor when its size would change.
+To fix this issue, we added a prop to `Icon` called `key`. Its value is a string that changes value whenever
+`iconSize` changes value. It is also a unique string, meaning that if we have multiple icons they each need to
 have their own key value. 
 
 With this key prop, `Icon` will automatically re-render every time the icon size prop changes.

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -25,6 +25,8 @@ module.exports = {
           "marketplace/examples/example-menu",
           "marketplace/examples/example-slider",
           "marketplace/examples/example-custom-webpack",
+          "marketplace/examples/example-force-rerender",
+          "marketplace/examples/example-editor-prop",
         ],
       },
     ],


### PR DESCRIPTION
Added examples for the following:
- Forcing a React component to re-render using React's `key` prop
- Conditionally rendering based on context. This can be used to render a static image instead of the actual component in the editor.
- Color contrast (just made modifications to the "app-branding" doc)