### PR TITLE
Fix "enable developer mode" link in create-new-adalo-library.md

### DIFF
--- a/website/docs/marketplace/create-new-adalo-library.md
+++ b/website/docs/marketplace/create-new-adalo-library.md
@@ -9,7 +9,7 @@ It sets up your base environment for building custom components for adalo by ins
 
 ## Creating a new library
 
-You'll need to have [Node](https://nodejs.org) `>=10.2` on your machine, and you need to [enable developer mode](marketplace/enabling-developer-mode) on your Adalo account. Then to create a component, run:
+You'll need to have [Node](https://nodejs.org) `>=10.2` on your machine, and you need to [enable developer mode](enabling-developer-mode) on your Adalo account. Then to create a component, run:
 
 ```bash
 npx create-adalo-component my-component


### PR DESCRIPTION
The "enable developer mode" link in the [create-new-adalo-library.md](https://github.com/AdaloHQ/docs/blob/master/website/docs/marketplace/create-new-adalo-library.md) file is broken 😞 