### PR TITLE
Fix "enable developer mode" links in Getting Started and Create a New Adalo Library

### DIFF
--- a/website/docs/marketplace/create-new-adalo-library.md
+++ b/website/docs/marketplace/create-new-adalo-library.md
@@ -9,7 +9,7 @@ It sets up your base environment for building custom components for adalo by ins
 
 ## Creating a new library
 
-You'll need to have [Node](https://nodejs.org) `>=10.2` on your machine, and you need to [enable developer mode](marketplace/enabling-developer-mode) on your Adalo account. Then to create a component, run:
+You'll need to have [Node](https://nodejs.org) `>=10.2` on your machine, and you need to [enable developer mode](marketplace/enabling-developer-mode.md) on your Adalo account. Then to create a component, run:
 
 ```bash
 npx create-adalo-component my-component

--- a/website/docs/marketplace/getting-started.md
+++ b/website/docs/marketplace/getting-started.md
@@ -3,7 +3,7 @@ id: getting-started
 title: Getting Started
 ---
 
-You'll need to have [Node](https://nodejs.org) `>=10.2` on your machine, and you need to [enable developer mode](enabling-developer-mode) on your Adalo account. Then to create a component, run:
+You'll need to have [Node](https://nodejs.org) `>=10.2` on your machine, and you need to [enable developer mode](marketplace/enabling-developer-mode.md) on your Adalo account. Then to create a component, run:
 
 ```bash
 npx create-adalo-component my-component


### PR DESCRIPTION
This PR will address #17 along with an additional area that was affected.