### PR TITLE
Add Icon documentation

### DIFF
--- a/website/docs/docs/design/icons.md
+++ b/website/docs/docs/design/icons.md
@@ -1,0 +1,28 @@
+---
+id: icons
+title: Icons
+---
+
+Inside a component's manifest, one of the [Adalo datatypes](/api-reference/manifest-json#type) you can use is the icon datatype.
+
+In order to use icons in Adalo, you must install [react-native-vector-icons](https://github.com/oblador/react-native-vector-icons) and import the material icons.
+
+The prop with type icon, when it reaches your component, will simply be a string that's the name of the icon specified in the editor.
+
+Use this example for reference: 
+```javascript
+// index.js
+import React, { Component } from 'react'
+import Icon from 'react-native-vector-icons/MaterialIcons'
+
+class MyComponent extends Component {
+    render() {
+        const { icon } = this.props
+        return <Icon name={icon}/>
+    }
+}
+```
+
+:::note
+When you set defaults for an icon prop inside your manifest, make sure to use hyphens instead of underscores between words.
+:::

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -23,6 +23,7 @@ module.exports = {
       "docs/design/colors-branding",
       "docs/design/resizing",
       "docs/design/images",
+      "docs/design/icons",
     ],
     Interactions: [
       "docs/interactions/standards",


### PR DESCRIPTION
Previously, there was no documentation on how icons work within Adalo, so I added a new doc under design that explains how to use icons.