### PR TITLE
Remove npm from docs as we no longer use npm

### DIFF
--- a/website/docs/docs/basics/publishing.md
+++ b/website/docs/docs/basics/publishing.md
@@ -3,6 +3,6 @@ id: publishing
 title: Publishing
 ---
 
-To publish your component, all you need to do is run `npx adalo publish`. The command will bundle your library, publish it to Adalo's npm registry, and add it to Adalo's component registry.
+To publish your component, all you need to do is run `npx adalo publish`. The command will bundle your library and add it to Adalo's component registry.
 
 Before you publish, make sure that your `package.json` is fully filled out. See [publishing](/docs/workflow/publishing) for more details.


### PR DESCRIPTION
Removed mention of `npm`  from our publishing documentation as we have removed this dependency from our marketplace libraries.