### PR TITLE
Provide a less intimidating default webpack setup

### DIFF
--- a/website/docs/docs/workflow/webpack.md
+++ b/website/docs/docs/workflow/webpack.md
@@ -43,7 +43,7 @@ If you choose to specify your own webpack config file, you are welcome to use th
 
 ```javascript
 const webpack = require('webpack')
-const {AdaloDefaultConfig} = require('@adalo/cli/src/webpackConfig')
+const { AdaloDefaultConfig } = require('@adalo/cli/src/webpackConfig')
 
 /**
  * Determine if we're in dev mode or production mode based on the 

--- a/website/docs/docs/workflow/webpack.md
+++ b/website/docs/docs/workflow/webpack.md
@@ -39,7 +39,7 @@ Make sure to make your config the only export of the webpack config file.
 
 If you choose to specify your own webpack config file, you are welcome to use this file as a starting point.
 
-> This example expects you to have the Adalo CLI installed as a dev dependency of your component: `yarn install --dev @adalo/cli`
+> This example expects you to have the Adalo CLI installed as a dev dependency of your component: `yarn add --dev @adalo/cli`
 
 ```javascript
 const webpack = require('webpack')

--- a/website/docs/docs/workflow/webpack.md
+++ b/website/docs/docs/workflow/webpack.md
@@ -39,57 +39,25 @@ Make sure to make your config the only export of the webpack config file.
 
 If you choose to specify your own webpack config file, you are welcome to use this file as a starting point.
 
+> This example expects you to have the Adalo CLI installed as a dev dependency of your component: `yarn install --dev @adalo/cli`
+
 ```javascript
 const webpack = require('webpack')
-const defaultConfig = {
-  module: {
-    rules: [
-      {
-        test: /\.js$/,
-        use: {
-          loader: 'babel-loader',
-          options: {
-            presets: ['@babel/preset-react', '@babel/preset-env'],
-            plugins: ['@babel/plugin-proposal-class-properties'],
-          },
-        },
-      },
-      {
-        test: /\.css$/,
-        use: ['style-loader', 'css-loader'],
-      },
-      {
-        test: [/\.bmp$/, /\.gif$/, /\.jpe?g$/, /\.png$/, /\.ttf$/, /\.otf$/],
-        loader: require.resolve('url-loader'),
-        options: {
-          // limit: 10000,
-          name: 'static/media/[name].[hash:8].[ext]',
-        },
-      },
-    ],
-  },
-  externals: {
-    react: 'React',
-    'react-native': 'ReactNative',
-  },
-  resolve: {
-    modules: ['node_modules'],
-    extensions: [
-      '.web.js',
-      '.js',
-      '.json',
-      '.web.jsx',
-      '.jsx',
-      '.web.react.js',
-      '.react.js',
-    ],
-  },
-  plugins: [
-    new webpack.optimize.LimitChunkCountPlugin({
-      maxChunks: 1,
-    }),
-  ],
+const {AdaloDefaultConfig} = require('@adalo/cli/src/webpackConfig')
+
+/**
+ * Determine if we're in dev mode or production mode based on the 
+ * build command: `adalo dev` or `adalo build`
+ */
+const MODE = process.argv.includes('dev') ? 'DEVELOPMENT' : 'PRODUCTION';
+
+if(MODE === "DEVELOPMENT"){
+    AdaloDefaultConfig.plugins.push(
+        // some development plugin
+    )
 }
 
-module.exports = defaultConfig,
+// Modify defaultConfig as needed
+
+module.exports = AdaloDefaultConfig
 ```


### PR DESCRIPTION
The dev/production code may be overkill and may confuse users. The main point of this document, though, is to show that the default webpack config can be imported and modified.