### PR TITLE
Added image instructions to Design -> Image doc

### DIFF
--- a/website/docs/docs/design/images.md
+++ b/website/docs/docs/design/images.md
@@ -8,3 +8,32 @@ Currently there's an issue with using React Native's `Image` component with stat
 :::
 
 Sometimes, instead of rendering certain parts of your component in the editor, you may want to just render a placeholder image. For example, the maps component renders a static placeholder image instead of the actual maps component in the editor. See ["Component Rendering"](/docs/interactions/component-rendering) for more information on how to render a placeholder image in the editor.
+
+## Using Images in Your Component
+
+Inside a component's manifest, one of the [Adalo datatypes](/api-reference/configuration/manifest-json#type) you can use is the image datatype.
+
+In order to use images in Adalo, you must import and use the ```Image``` component provided by React Native instead of React's `<img>` tag.
+
+Use this example and React Native's [documentation](https://reactnative.dev/docs/image) for reference:
+
+```javascript
+// index.js
+import React, { Component } from "react";
+import { Image } from 'react-native'
+
+class MyComponent extends Component {
+  render() {
+    const { image } = this.props;
+    return (
+        <Image
+						style={{ height: 100, width: 100 }}
+						source={image} 
+				/>
+    );
+  }
+}
+```
+:::note
+```Image``` components will only render if both width and height are specified. ```img``` tags will not render in the application preview.
+:::


### PR DESCRIPTION
Scott--not sure if the note at the top of this page (which says that React Native's Image component doesn't work) is still relevant. It's a bit confusing so I think we might be able to remove it.