### PR TITLE
Demo Apps are required for all Libraries now

### DIFF
--- a/website/docs/component-standards/configuration/adalo-json.md
+++ b/website/docs/component-standards/configuration/adalo-json.md
@@ -13,6 +13,7 @@ The `adalo.json` file used to define information about your library. Every libra
 - `author`
 - `description`
 - `logo`
+- `demoAppURL`
 - `supportURL`
 - `requiresThirdPartySubscription`
 - `components`
@@ -20,7 +21,6 @@ The `adalo.json` file used to define information about your library. Every libra
 Additionally, all paid libraries should also contain the following:
 
 - `price`
-- `demoAppURL`
 
 You can also include the following optional fields:
 


### PR DESCRIPTION
`DemoAppURL` was initially only required for premium (aka paid) component libraries, but after realizing that the demo apps made reviews much easier, I decided we should make them required for all apps going forward.