### PR TITLE
fix: change adalo to @adalo/cli in npx commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Adalo Docs
+
 Documentation for creating Adalo libraries
 
 ## Creating Libraries
@@ -40,7 +41,6 @@ In `package.json` you need to add an additional section called `"adalo"` that wi
 
 See the [Component Manifest Documentation](https://github.com/AdaloHQ/docs/blob/main/libraries/Manifests.md) to learn what to put inside your manifest.json file.
 
-
 ## Testing Locally
 
 In order to test your package locally, you need to add a package dependency to your project:
@@ -58,10 +58,9 @@ yarn add @adalo/cli
 Then, to run the package locally, to make it accessible in Adalo, run:
 
 ```
-npx adalo dev
+npx @adalo/cli dev
 ```
 
 The first time you run this, you'll be asked to login using your Adalo account. This is in order to allow you to use the package in your account on Adalo.
 
 After you've successfully logged in and run `npx proton dev` again, you can go to Adalo and click the Add Layer button and you should see your package available at the bottom of the list of components.
-

--- a/website/docs/docs/basics/create-adalo-component.md
+++ b/website/docs/docs/basics/create-adalo-component.md
@@ -16,10 +16,10 @@ npx create-adalo-component my-component
 cd my-component
 
 # login with your adalo credentials
-npx adalo login
+npx @adalo/cli login
 
 # start the development server
-npx adalo dev
+npx @adalo/cli dev
 ```
 
 ...then go to Adalo and add a new component to one of your screens. In the **Add** menu you should see a new section called "Development" where you'll find your new component.

--- a/website/docs/docs/basics/tutorial.md
+++ b/website/docs/docs/basics/tutorial.md
@@ -16,10 +16,10 @@ npx create-adalo-component my-component
 cd my-component
 
 # login with your adalo credentials
-npx adalo login
+npx @adalo/cli login
 
 # start the development server
-npx adalo dev
+npx @adalo/cli dev
 ```
 
 You can find more information in the [Creating a Component](/docs/basics/create-adalo-component) docs.
@@ -30,7 +30,7 @@ Now, when you log in to your account on Adalo's website and open an app, a new t
 
 Inside your component, you will find a folder labelled `src`, and inside there a folder for the name of your first component. Inside, you'll find two files: `manifest.json` and `index.js`. The `manifest.json` contains all of the configuration for your component. Adalo's editor parses this file and uses it to generate the settings on the left panel in the editor, and each prop inside the manifest is passed down to your component as a React prop. See the [configuration docs](/docs/configuration/manifest-json) for more information.
 
-Edits to `index.js` are automatically reflected in the editor; however, changes to the `manifest.json` will only show up in the editor after a refresh (pressing `^C` in the terminal and running `npx adalo dev` again).
+Edits to `index.js` are automatically reflected in the editor; however, changes to the `manifest.json` will only show up in the editor after a refresh (pressing `^C` in the terminal and running `npx @adalo/cli dev` again).
 
 ### Testing your library
 

--- a/website/docs/docs/workflow/testing.md
+++ b/website/docs/docs/workflow/testing.md
@@ -26,10 +26,10 @@ To do so, run in your shell:
 
 ```bash
 # login with your adalo credentials
-npx adalo login
+npx @adalo/cli login
 
 # start the development server
-npx adalo dev
+npx @adalo/cli dev
 ```
 
 Now, when you add a component on Adalo, you will see a new tab called "development" with your component.


### PR DESCRIPTION
## Problem
`npx adalo` commands are not working properly, so we need to change the docs to reflect what actually works

## Solution
`npx @adalo/cli` commands work fine so that's what it got changed to