### PR TITLE
Add documentation around layout property

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,8 +57,14 @@ yarn add @adalo/cli
 
 Then, to run the package locally, to make it accessible in Adalo, run:
 
+```bash
+adalo dev
 ```
-npx @adalo/cli dev
+
+or:
+
+```bash
+npx adalo dev
 ```
 
 The first time you run this, you'll be asked to login using your Adalo account. This is in order to allow you to use the package in your account on Adalo.

--- a/website/docs/docs/basics/create-adalo-component.md
+++ b/website/docs/docs/basics/create-adalo-component.md
@@ -16,10 +16,10 @@ npx create-adalo-component my-component
 cd my-component
 
 # login with your adalo credentials
-npx @adalo/cli login
+npx adalo login
 
 # start the development server
-npx @adalo/cli dev
+npx adalo dev
 ```
 
 ...then go to Adalo and add a new component to one of your screens. In the **Add** menu you should see a new section called "Development" where you'll find your new component.

--- a/website/docs/docs/basics/tutorial.md
+++ b/website/docs/docs/basics/tutorial.md
@@ -16,10 +16,10 @@ npx create-adalo-component my-component
 cd my-component
 
 # login with your adalo credentials
-npx @adalo/cli login
+npx adalo login
 
 # start the development server
-npx @adalo/cli dev
+npx adalo dev
 ```
 
 You can find more information in the [Creating a Component](/docs/basics/create-adalo-component) docs.
@@ -30,7 +30,7 @@ Now, when you log in to your account on Adalo's website and open an app, a new t
 
 Inside your component, you will find a folder labelled `src`, and inside there a folder for the name of your first component. Inside, you'll find two files: `manifest.json` and `index.js`. The `manifest.json` contains all of the configuration for your component. Adalo's editor parses this file and uses it to generate the settings on the left panel in the editor, and each prop inside the manifest is passed down to your component as a React prop. See the [configuration docs](/docs/configuration/manifest-json) for more information.
 
-Edits to `index.js` are automatically reflected in the editor; however, changes to the `manifest.json` will only show up in the editor after a refresh (pressing `^C` in the terminal and running `npx @adalo/cli dev` again).
+Edits to `index.js` are automatically reflected in the editor; however, changes to the `manifest.json` will only show up in the editor after a refresh (pressing `^C` in the terminal and running `npx adalo dev` again).
 
 ### Testing your library
 

--- a/website/docs/docs/configuration/manifest-json.md
+++ b/website/docs/docs/configuration/manifest-json.md
@@ -112,19 +112,6 @@ The layout property is used for responsive components. It can define the compone
 
 - See Layout Configuration for supported values of `shared` property.
 
-### Example Layout
-
-```json
-{
-  "displayName": "Component",
-  "layout": {
-    "sticky": true,
-    "shared": "FIXED_LEFT",
-    "mobile": "SCALES_RELATIVE"
-  }
-}
-```
-
 ### Layout Configuration
 
 | Name            | Width Resizing     | Anchored       |
@@ -143,6 +130,19 @@ The layout property is used for responsive components. It can define the compone
 | \_screenHeight | number                            | Provides the current screen height in editor or device height in runner. |
 | \_screenWidth  | number                            | Provides the current screen width in editor or device width in runner.   |
 | \_layoutGuides | { top: number, bottom: number }   | Provides Safe Area Inset values for `top` and `bottom`                   |
+
+### Example Layout
+
+```json
+{
+  "displayName": "Component",
+  "layout": {
+    "sticky": true,
+    "shared": "FIXED_LEFT",
+    "mobile": "SCALES_RELATIVE"
+  }
+}
+```
 
 ## Props
 

--- a/website/docs/docs/configuration/manifest-json.md
+++ b/website/docs/docs/configuration/manifest-json.md
@@ -90,10 +90,59 @@ Child components are simply a way to organize your props into different sections
 
 The path to the icon for this component. This will be used as a thumbnail in the Components Panel. See the [thumbnail guidelines](/component-standards/component-listing/thumbnail) for information on the logo guidelines.
 
-
 #### Example Icon
 
 <img src="/img/example-icon.png" alt="Example icon for a Libraries Component" />
+
+## `layout`
+
+- Type: `Object`
+
+The layout property is used for responsive components. It can define the component resizing across different screen sizes and set the component's position on the screen.
+
+### Properties
+
+| Name      | Type    | Description                                                                                          |
+| --------- | ------- | ---------------------------------------------------------------------------------------------------- |
+| `sticky`  | boolean | decides whether the component will be absolutely positioned or relative.                             |
+| `shared`  | string  | Layout Settings that will be shared across all breakpoints that do not have a Custom Layout Setting. |
+| `desktop` | string  | Custom Layout Setting for Desktop Breakpoint. See Layout Configuration for supported values.         |
+| `tablet`  | string  | Custom Layout Setting for Tablet Breakpoint. See Layout Configuration for supported values.          |
+| `mobile`  | string  | Custom Layout Setting for Mobile Breakpoint. See Layout Configuration for supported values.          |
+
+- See Layout Configuration for supported values of `shared` property.
+
+### Example Layout
+
+```json
+{
+  "displayName": "Component",
+  "layout": {
+    "sticky": true,
+    "shared": "FIXED_LEFT",
+    "mobile": "SCALES_RELATIVE"
+  }
+}
+```
+
+### Layout Configuration
+
+| Name            | Width Resizing     | Anchored       |
+| --------------- | ------------------ | -------------- |
+| SCALES_RELATIVE | Scales with Screen | Center         |
+| SCALES_FIXED    | Scales with Screen | Left and Right |
+| FIXED_LEFT      | Fixed              | Left           |
+| FIXED_RIGHT     | Fixed              | Right          |
+| FIXED_CENTER    | Fixed              | CENTER         |
+
+#### Additional Props
+
+| Name           | Type                              | Description                                                              |
+| -------------- | --------------------------------- | ------------------------------------------------------------------------ |
+| \_deviceType   | "mobile" \| "tablet" \| "desktop" | Provides the current device.                                             |
+| \_screenHeight | number                            | Provides the current screen height in editor or device height in runner. |
+| \_screenWidth  | number                            | Provides the current screen width in editor or device width in runner.   |
+| \_layoutGuides | { top: number, bottom: number }   | Provides Safe Area Inset values for `top` and `bottom`                   |
 
 ## Props
 

--- a/website/docs/docs/workflow/testing.md
+++ b/website/docs/docs/workflow/testing.md
@@ -6,18 +6,18 @@ title: Testing
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-Not only is it important that you write your component to be cross-platform, you must also test your component on all platforms. 
+Not only is it important that you write your component to be cross-platform, you must also test your component on all platforms.
 
 If you are trying to test a library after you've published it, check out [managing public libraries](/docs/workflow/managing-public-libraries).
 
 <Tabs
-  defaultValue="web"
-  values={[
-    {label: 'Web', value: 'web'},
-    {label: 'iOS', value: 'ios'},
-    {label: 'Android', value: 'android'},
-  ]}>
-  <TabItem value="web">
+defaultValue="web"
+values={[
+{label: 'Web', value: 'web'},
+{label: 'iOS', value: 'ios'},
+{label: 'Android', value: 'android'},
+]}>
+<TabItem value="web">
 
 ## Web
 
@@ -26,17 +26,17 @@ To do so, run in your shell:
 
 ```bash
 # login with your adalo credentials
-npx @adalo/cli login
+npx adalo login
 
 # start the development server
-npx @adalo/cli dev
+npx adalo dev
 ```
 
 Now, when you add a component on Adalo, you will see a new tab called "development" with your component.
 Changes to the code will hot reload the page **besides** changes to any `manifest.json`. If you make any changes
 to `manifest.json`, you must restart your component.
-  </TabItem>
-  <TabItem value="ios">
+</TabItem>
+<TabItem value="ios">
 
 ## iOS
 
@@ -106,11 +106,12 @@ If your component requires custom configuration, you can instruct the Adalo buil
 This section will organically grow over time as developers run into more build issues...
 
 #### Common build issues and how to fix them:
+
 - `pod install` fails on line `use_native_modules!`
   - Make sure Node is properly installed. Run `node -v`. If this fails, download and run the node js installer from their website.
 - `pod install` fails with an error that looks like "SDK "iphoneos" cannot be located"
-  - You likely installed XCode's command line tools separately before installing XCode's editor. See [this](https://www.ryadel.com/en/xcode-sdk-iphoneos-cannot-be-located-mac-osx-error-fix/) post for more details.
 
+  - You likely installed XCode's command line tools separately before installing XCode's editor. See [this](https://www.ryadel.com/en/xcode-sdk-iphoneos-cannot-be-located-mac-osx-error-fix/) post for more details.
 
   </TabItem>
   <TabItem value="android">
@@ -179,14 +180,16 @@ If your component requires custom configuration, you can instruct the Adalo buil
 ### Troubleshooting
 
 This section will organically grow over time as developers run into more build issues...
+
 #### Common build issues and how to fix them:
+
 - If you run into an error that looks like: `java.lang.NoClassDefFoundError: Could not initialize class org.codehaus.groovy.vmplugin.v7.Java7`
   - Update gradle. To do so, open `mobile-previewer/android/gradle/wrapper/gradle-wrapper.properties`. Change `distributionUrl` to be: `distributionUrl=https\://services.gradle.org/distributions/gradle-6.3-all.zip`.
 - If you run into an error that looks like "Missing SDK path".
-  - Add a new file `mobile-previewer/android/local.properties`, which will only have one line: `sdk.dir=/path/to/android/sdk/locally`. On mac, this path will look like `/Users/username/Library/Android/sdk`, where `username` is your username. 
+  - Add a new file `mobile-previewer/android/local.properties`, which will only have one line: `sdk.dir=/path/to/android/sdk/locally`. On mac, this path will look like `/Users/username/Library/Android/sdk`, where `username` is your username.
 - If you run into an error that looks like `Execution failed for task ':react-native-action-sheet:javaPreCompileDebug'.`, or `Failed to transform react-native-0.71.0-rc.0-debug.aar`:
+
   - Open `package.json` and under `dependencies`, set the `react-native` version to `0.63`, i.e. change the line to `"react-native": "0.63",`.
 
-
-  </TabItem>
-</Tabs>
+    </TabItem>
+  </Tabs>

--- a/website/docs/docs/workflow/testing.md
+++ b/website/docs/docs/workflow/testing.md
@@ -111,10 +111,10 @@ This section will organically grow over time as developers run into more build i
   - Make sure Node is properly installed. Run `node -v`. If this fails, download and run the node js installer from their website.
 - `pod install` fails with an error that looks like "SDK "iphoneos" cannot be located"
 
-  - You likely installed XCode's command line tools separately before installing XCode's editor. See [this](https://www.ryadel.com/en/xcode-sdk-iphoneos-cannot-be-located-mac-osx-error-fix/) post for more details.
+- You likely installed XCode's command line tools separately before installing XCode's editor. See [this](https://www.ryadel.com/en/xcode-sdk-iphoneos-cannot-be-located-mac-osx-error-fix/) post for more details.
 
-  </TabItem>
-  <TabItem value="android">
+</TabItem>
+<TabItem value="android">
 
 ## Android
 
@@ -189,7 +189,7 @@ This section will organically grow over time as developers run into more build i
   - Add a new file `mobile-previewer/android/local.properties`, which will only have one line: `sdk.dir=/path/to/android/sdk/locally`. On mac, this path will look like `/Users/username/Library/Android/sdk`, where `username` is your username.
 - If you run into an error that looks like `Execution failed for task ':react-native-action-sheet:javaPreCompileDebug'.`, or `Failed to transform react-native-0.71.0-rc.0-debug.aar`:
 
-  - Open `package.json` and under `dependencies`, set the `react-native` version to `0.63`, i.e. change the line to `"react-native": "0.63",`.
+- Open `package.json` and under `dependencies`, set the `react-native` version to `0.63`, i.e. change the line to `"react-native": "0.63",`.
 
-    </TabItem>
-  </Tabs>
+</TabItem>
+</Tabs>


### PR DESCRIPTION
## Description
A new property for library components was added as part of the new responsive engine.
This property handles resizing and component's position on the screen.

Since the `layout` property is an `object`, there are tables detailing each available property that can be used.

## Preview
https://github.com/AdaloHQ/docs/assets/28742636/195d5173-9a1a-4b3f-91a0-9674d0f5adbe

